### PR TITLE
use first audio/subtitle track when best_track could not be confirmed

### DIFF
--- a/impd
+++ b/impd
@@ -182,7 +182,7 @@ extract_subtitles() {
 		-an \
 		-i "$input" \
 		-map_metadata -1 \
-		-map "0:${track_num:-s}" \
+		-map "0:${track_num:-s:0}" \
 		-f "${output##*.}" \
 		"$output" &&
 		echo "$output has been written."
@@ -228,7 +228,7 @@ extract_audio() {
 		-sn \
 		-i "$input" \
 		-map_metadata -1 \
-		-map "0:${track_num:-a}" \
+		-map "0:${track_num:-a:0}" \
 		-ac 2 \
 		-ab "$bitrate" \
 		-vbr on \


### PR DESCRIPTION
When dealing with files which contain multiple unnamed subtitle (or audio) tracks, the `best_track` function will not return anything and the ffmpeg will use `-s` (or `-a`) as map parameter. According to the ffmpeg [docs](https://ffmpeg.org/ffmpeg.html#Advanced-options) this will select all suitable streams. This causes the subtitle extract to fail with the error below

> [srt @ 0x558672431600] SRT supports only a single subtitles stream.
Could not write header for output file #0 (incorrect codec parameters ?): Invalid argument
Error initializing output stream 0:1 -- 
