### PR TITLE
Fix timestamp parsing in certain locales (#13)

### DIFF
--- a/impd
+++ b/impd
@@ -374,7 +374,7 @@ sub_conv() {
 }
 
 parse_speech_fragments() {
-	awk -F' --> ' -vPADDING="$padding" -vSRT_TIMING_PATTERN="$srt_timing_pattern" '
+	LC_NUMERIC=C awk -F' --> ' -vPADDING="$padding" -vSRT_TIMING_PATTERN="$srt_timing_pattern" '
 	function time_parts_to_seconds(hours, mins, secs) {
 		return hours * 3600.0 + mins * 60.0 + secs
 	}


### PR DESCRIPTION
## Description
This pull request addresses issue #13 where the `parse_speech_fragments` function incorrectly parses timestamps on certain locales on certain systems, such as `sv_SE.UTF-8` on Tuxedo OS. The fix enforces a consistent numeric locale by setting `LC_NUMERIC=C` for the `awk` command within the function.

## Changes
- Modified the `parse_speech_fragments` function to include `LC_NUMERIC=C` for the `awk` command.

## Issue Link
This pull request resolves #13.

## Environment Tested
- OS: Tuxedo OS (Ubuntu-based distribution)
- Numeric Locale: `sv_SE.UTF-8` (Swedish)

## Testing Instructions
1. Ensure the numeric locale is set to a problematic one (e.g., `LC_NUMERIC=sv_SE.UTF-8`) on Tuxedo OS or possibly another Ubuntu-based distribution.
2. Run `impd add` or `impd condense` to condense audio from video with subtitles.
3. Verify that the timestamps are parsed correctly and the process completes without errors, confirming that the override works as intended.