### PR TITLE
cleans chunklist by commenting out lines that aren't filenames

### DIFF
--- a/impd
+++ b/impd
@@ -670,11 +670,13 @@ make_condensed() {
 
 		local start end chunk_path
 		while IFS=, read -r start end; do
-			echo "Processing chunk from $start to $end..." >&3
+			echo "Processing chunk from $start to $end..."
 			chunk_path=$chunks_dir/${base}_${start}-${end}.ogg
 			make_chunk "$temp_audio" "$chunk_path" "$start" "$end"
-			if [[ -f $chunk_path ]]; then echo "file '$chunk_path'"; fi
-		done < <(filter_non_speech_fragments <"${subs_out:?}" | parse_speech_fragments) 3>&1 >"$chunks_file"
+			if [[ -f $chunk_path ]]; then
+				echo "file '$chunk_path'" >&3
+			fi
+		done < <(filter_non_speech_fragments <"${subs_out:?}" | parse_speech_fragments) 3>"$chunks_file"
 
         remove_garbage "$chunks_file"
 		concat_audio "$chunks_file" "$temp_audio"

--- a/impd
+++ b/impd
@@ -609,11 +609,6 @@ add_metadata() {
 		"$output"
 }
 
-remove_garbage() {
-    local -r chunks_file=$1
-    sed -i '/^file/! s/^/#/' "$chunks_file"
-}
-
 concat_audio() {
 	local -r chunks_file=$1 output=$2
 	ffmpeg -nostdin \
@@ -678,7 +673,6 @@ make_condensed() {
 			fi
 		done < <(filter_non_speech_fragments <"${subs_out:?}" | parse_speech_fragments) 3>"$chunks_file"
 
-        remove_garbage "$chunks_file"
 		concat_audio "$chunks_file" "$temp_audio"
 		add_metadata "$temp_audio" "$output"
 	}

--- a/impd
+++ b/impd
@@ -609,6 +609,11 @@ add_metadata() {
 		"$output"
 }
 
+remove_garbage() {
+    local -r chunks_file=$1
+    sed -i '/^file/! s/^/#/' "$chunks_file"
+}
+
 concat_audio() {
 	local -r chunks_file=$1 output=$2
 	ffmpeg -nostdin \
@@ -671,6 +676,7 @@ make_condensed() {
 			if [[ -f $chunk_path ]]; then echo "file '$chunk_path'"; fi
 		done < <(filter_non_speech_fragments <"${subs_out:?}" | parse_speech_fragments) 3>&1 >"$chunks_file"
 
+        remove_garbage "$chunks_file"
 		concat_audio "$chunks_file" "$temp_audio"
 		add_metadata "$temp_audio" "$output"
 	}


### PR DESCRIPTION
fixes #18 
this pr comments out lines that don't start with `file` in `chunks.list` so that ffmpeg can concat the files in said list.