### PR TITLE
add option '-c' to ignore chapters matching a regex

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,10 @@ Can be used to skip openings and endings by matching lines like `♪〜`.
 * `extract_audio_add_args`.
   Defines an array of additional arguments which should be passed to `ffmpeg`
   when extracting audio tracks from videos.
+* `ignored_chapters_pattern`. Awk RegExp to match chapters in the input file.
+  If it matches, any subtitle inside the chapter start and end time is ignored.
+  By default, it is set to ignore chapters whose name contains `PV`, `OP`, `ED`, or `Intro`.
+
 
 **Example config file:**
 
@@ -113,6 +117,7 @@ padding=0.2
 line_skip_pattern="^♪〜$|^〜♪$"
 filename_skip_pattern="NCOP|NCED"
 extract_audio_add_args=(-af loudnorm=I=-16:TP=-1.5:LRA=11)
+ignored_chapters_pattern="PV|OP|ED|Intro"
 ```
 
 If a value is omitted from the config file, the default value will be used.

--- a/impd
+++ b/impd
@@ -56,6 +56,10 @@ fetch_ignored_chapters() {
 filter_ignored_chapters() {
     # filters the timestamps that overlap with the ignored chapters.
 	local -r chapters_file=${1:?}
+	if ! [[ -s $chapters_file ]]; then
+		cat -
+		return
+	fi
 
 	awk -F',' '
 	NR==FNR {
@@ -729,13 +733,7 @@ make_condensed() {
 		done < <(
 			filter_non_speech_fragments <"${subs_out:?}" |
 			parse_speech_fragments |
-			{
-				if [[ -s $ignored_chapters_file ]]; then
-					filter_ignored_chapters "$ignored_chapters_file"
-				else
-					cat
-				fi
-			}
+			filter_ignored_chapters "$ignored_chapters_file"
 		) 3>"$chunks_file"
 
 		concat_audio "$chunks_file" "$temp_audio"

--- a/impd
+++ b/impd
@@ -31,6 +31,52 @@ declare -a extract_audio_add_args=('-af' 'loudnorm=I=-16:TP=-1.5:LRA=11')
 # to prevent attempts to convert the same file twice.
 declare -A converted_map
 
+fetch_ignored_chapters() {
+	# Print ignored chapters present in container, 1 chatper per line.
+	# Format: start_time,end_time
+	local -r video=${1:?}
+	local -r pattern=${2:?}
+
+	ffprobe \
+		-loglevel error \
+		-show_chapters \
+		-print_format csv=p=0 \
+		"$video" |
+	awk -F',' -vPATTERN="$pattern" '
+	{
+		start=$4
+		end=$6
+		title=$7
+		if (title ~ PATTERN) {
+			print start "," end
+		}
+	}'
+}
+
+filter_ignored_chapters() {
+    # filters the timestamps that overlap with the ignored chapters.
+	local -r chapters_file=${1:?}
+
+	awk -F',' '
+	NR==FNR {
+		ignore_start[NR]=$1
+		ignore_end[NR]=$2
+		count=NR
+		next
+	}
+	{
+		start=$1
+		end=$2
+		for (i=1; i<=count; i++) {
+			if (start < ignore_end[i] && end > ignore_start[i]) {
+				next
+			}
+		}
+		print
+	}
+	' "$chapters_file" -
+}
+
 probe_tracks() {
 	# Print tracks present in container, separated by tabs.
 	# Format: index,lang,title,type
@@ -644,6 +690,10 @@ make_condensed() {
 	local -r subs_track_num=${4-}
 	local -r audio_track_num=${5-}
 
+	local -r ignored_chapters=${6-}
+
+	local -r ignored_chapters_file=$job_dir/ignored_chapters.list
+
 	_make_condensed() {
 		if ! check_output; then
 			return 1
@@ -651,6 +701,11 @@ make_condensed() {
 
 		if [[ -n $subs_track_num ]] && ! [[ $subs_track_num =~ ^[0-9]+$ ]]; then
 			echo "Provided subtitle track number isn't a numeric value."
+			return 1
+		fi
+
+		if [[ -n $ignored_chapters ]] && ! fetch_ignored_chapters "$video" "$ignored_chapters" > "$ignored_chapters_file"; then
+			echo "Error while fetching ignored chapters."
 			return 1
 		fi
 
@@ -672,7 +727,17 @@ make_condensed() {
 			if [[ -f $chunk_path ]]; then
 				echo "file '$chunk_path'" >&3
 			fi
-		done < <(filter_non_speech_fragments <"${subs_out:?}" | parse_speech_fragments) 3>"$chunks_file"
+		done < <(
+			filter_non_speech_fragments <"${subs_out:?}" |
+			parse_speech_fragments |
+			{
+				if [[ -s $ignored_chapters_file ]]; then
+					filter_ignored_chapters "$ignored_chapters_file"
+				else
+					cat
+				fi
+			}
+		) 3>"$chunks_file"
 
 		concat_audio "$chunks_file" "$temp_audio"
 		add_metadata "$temp_audio" "$output"
@@ -698,10 +763,11 @@ condense() {
 		echo -n "-s [SUBTITLES FILE] "
 		echo -n "-o [OUTPUT FILE] "
 		echo -n "-t [SUBTITLE TRACK NUMBER] "
+		echo -n "-c [CHAPTER NAME REGEX] "
 		echo "-a [AUDIO TRACK NUMBER] "
 		return 1
 	fi
-	while getopts 'i: s: o: t: a:' flag; do
+	while getopts 'i: s: o: t: c: a:' flag; do
 		case $flag in
 		i)
 			local -r input=${OPTARG}
@@ -715,6 +781,9 @@ condense() {
 			;;
 		t)
 			local -r subs_track_num=${OPTARG}
+			;;
+		c)
+			local -r ignored_chapters=${OPTARG}
 			;;
 		a)
 			local -r audio_track_num=${OPTARG}
@@ -730,7 +799,8 @@ condense() {
 		"${output-}" \
 		"${subtitles-}" \
 		"${subs_track_num-}" \
-		"${audio_track_num-}" || true
+		"${audio_track_num-}" \
+		"${ignored_chapters-}" || true
 }
 
 notify_send() {
@@ -1065,6 +1135,7 @@ echo_help() {
 		  -o|optional output file
 		  -s|optional subtitle file
 		  -t|optional subtitle track number, if internal subtitles should be used
+		  -c|optional regex of chapter names, internal chapter names matching this will be ignored (e.g. OP|ED|Preview)
 		  -a|optional audio track number
 	EOF
 	echo

--- a/impd
+++ b/impd
@@ -691,7 +691,6 @@ make_condensed() {
 	local -r audio_track_num=${5-}
 
 	local -r ignored_chapters=${6-}
-
 	local -r ignored_chapters_file=$job_dir/ignored_chapters.list
 
 	_make_condensed() {
@@ -800,7 +799,7 @@ condense() {
 		"${subtitles-}" \
 		"${subs_track_num-}" \
 		"${audio_track_num-}" \
-		"${ignored_chapters-}" || true
+		"${ignored_chapters-${ignored_chapters_pattern-}}" || true
 }
 
 notify_send() {
@@ -1185,6 +1184,7 @@ set_config_defaults() {
 	readonly padding=${padding:-0.2}
 	readonly line_skip_pattern=${line_skip_pattern:-"^♬〜$|^♪?〜♪?$|^・～$|.*{\\be1}.*"}
 	readonly filename_skip_pattern=${filename_skip_pattern:-"NCOP|NCED"}
+	readonly ignored_chapters_pattern=${ignored_chapters_pattern:-"PV|OP|ED|Intro"}
 	readonly -a extract_audio_add_args
 }
 


### PR DESCRIPTION
Add a new flag to the condense command to ignore any text inside chapters matching the given regex.

Using ffmpeg you can see the chapters to get their names:
```bash
$ ffmpeg -i file.mkv
...
  Chapters:
    Chapter #0:0: start 0.033000, end 67.960000
      Metadata:
        title           : Prologue
    Chapter #0:1: start 67.960000, end 158.010000
      Metadata:
        title           : Opening
    Chapter #0:2: start 158.010000, end 539.020000
      Metadata:
        title           : Part A
    Chapter #0:3: start 539.020000, end 1300.030000
      Metadata:
        title           : Part B
    Chapter #0:4: start 1300.030000, end 1389.990000
      Metadata:
        title           : Ending
    Chapter #0:5: start 1389.990000, end 1421.464000
      Metadata:
        title           : Epilogue
```

Then to ignore chapters you don't want:
```bash
impd condense  -i file.mkv -c "Opening|Ending|Prologue"
```

I am not much of a shell script dev, and this is my first time using awk, so let me know if there's any issues. I tested on two different shows without issue.

