### PR TITLE
Use `/bin/bash` in shebang for better cross-system compatibility

### DIFF
--- a/impd
+++ b/impd
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/bash
 #
 # Immersion Pod - Passive listening management tool
 # Copyright (C) 2021 Ren Tatsumoto. <tatsu at autistici.org>

--- a/impd
+++ b/impd
@@ -1,4 +1,4 @@
-#!/usr/bin/bash
+#!/usr/bin/env bash
 #
 # Immersion Pod - Passive listening management tool
 # Copyright (C) 2021 Ren Tatsumoto. <tatsu at autistici.org>


### PR DESCRIPTION
Not all UNIX-based systems have Bash at `/usr/bin/bash`. On some Linux distributions and macOS, it may be located elsewhere (such as `/bin/bash`). Using `/usr/bin/env bash` lets the system find Bash via `PATH`, so the script runs more reliably across environments.

This change is also relevant to pull request #17, which aims to improve cross-platform compatibility (including environments where GNU tools or newer Bash versions may not be available by default).